### PR TITLE
Fix ZSH auto-completion

### DIFF
--- a/contrib/zsh-completion/_packer
+++ b/contrib/zsh-completion/_packer
@@ -31,8 +31,8 @@ _packer () {
 
   local -a validate_arguments && validate_arguments=(
     '-syntax-only[Only check syntax. Do not verify config of the template.]'
-    '-except=[(foo,bar,baz) Validate all builds other than these].'
-    '-only=[(foo,bar,baz) Validate only these builds].'
+    '-except=[(foo,bar,baz) Validate all builds other than these.]'
+    '-only=[(foo,bar,baz) Validate only these builds.]'
     '-var[("key=value") Variable for templates, can be used multiple times.]'
     '-var-file=[(path) JSON file containing user variables.]'
     '(-)*:files:_files -g "*.json"'


### PR DESCRIPTION
Closes #8158

This fixes the following errors when attempting to auto-complete with packer v.1.4.3:
(installed via Homebrew on macOS Mojave)

 `invalid option definition: -except=[(foo,bar,baz) Validate all builds other than these].`
 `invalid option definition: -only=[(foo,bar,baz) Validate only these builds].`